### PR TITLE
Add connection error banner with retry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, Navigate, Outlet } from 'react-router-dom';
 import { EntryRoomPage } from './pages/EntryRoomPage';
-import { Navigate, Outlet } from 'react-router-dom';
 import { ChatRoomPage } from './pages/ChatRoomPage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { useSelector } from 'react-redux';
 import { RootState } from './redux/store';
+import { useEffect, useState } from 'react';
+import { socket } from './websocket';
 
 interface ProtectedRouteProps {
   redirectPath: string;
@@ -19,16 +20,67 @@ export function ProtectedRoute({ redirectPath = '' }: ProtectedRouteProps) {
 }
 
 function App() {
+  const [connectionError, setConnectionError] = useState(false);
+
+  const retryConnection = () => {
+    socket.connect();
+  };
+
+  useEffect(() => {
+    socket.on('connect_error', () => {
+      console.warn('Socket connect error');
+      setConnectionError(true);
+    });
+
+    socket.on('disconnect', () => {
+      console.warn('Socket disconnected');
+      setConnectionError(true);
+    });
+
+    socket.on('connect', () => {
+      console.log('Socket connected');
+      setConnectionError(false);
+    });
+
+    return () => {
+      socket.off('connect_error');
+      socket.off('disconnect');
+      socket.off('connect');
+    };
+  }, []);
+
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="" element={<EntryRoomPage />} />
-        <Route element={<ProtectedRoute redirectPath="" />}>
-          <Route path="room" element={<ChatRoomPage />} />
-        </Route>
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </BrowserRouter>
+    <div>
+      {/* Error Banner */}
+      {connectionError && (
+        <div
+          className="bg-gray-100 border border-gray-400 text-gray-700 px-4 py-3 rounded fixed top-4 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md shadow-md flex justify-between items-center"
+          role="alert"
+          aria-live="assertive"
+        >
+          <p className="text-sm">
+            ⚠️ Connection lost. Please check your network or click Retry.
+          </p>
+          <button
+            onClick={retryConnection}
+            className="ml-4 bg-red-500 text-white text-xs px-3 py-1 rounded hover:bg-red-600"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Routes */}
+      <BrowserRouter>
+        <Routes>
+          <Route path="" element={<EntryRoomPage />} />
+          <Route element={<ProtectedRoute redirectPath="" />}>
+            <Route path="room" element={<ChatRoomPage />} />
+          </Route>
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </BrowserRouter>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Summary
This PR addresses the issue of improving error handling on the client-side when the Socket.io client fails to connect or disconnects unexpectedly. 

### What was done:
- Added a user-friendly toast/banner UI component that appears at the top center when the socket connection is lost.
- Included a "Retry" button inside the banner that attempts to reconnect the socket client.
- Integrated the banner and connection handling logic inside `App.tsx` for global error display.
- Added relevant socket event listeners for `connect_error`, `disconnect`, and `connect` events.
- Ensured the banner disappears automatically when the connection is re-established.

### Why it matters:
This improves the overall user experience by providing clear feedback about connection issues and allows users to manually retry connection without needing to reload the page. It adds resilience to the app in real-world network scenarios.

### Screenshots
<img width="975" height="506" alt="image" src="https://github.com/user-attachments/assets/b411ebf4-6880-4a2d-bbab-ea61124b99fd" />
<img width="975" height="517" alt="image" src="https://github.com/user-attachments/assets/9d0d01db-63ae-4b70-a363-0ecb0cfa75b2" />

